### PR TITLE
fix error with view import for django under 1.10

### DIFF
--- a/shared_session/views.py
+++ b/shared_session/views.py
@@ -8,7 +8,7 @@ from django.http.response import HttpResponse
 from django.middleware.csrf import get_token
 from django.utils import timezone
 from django.utils.http import cookie_date, urlsafe_base64_decode
-from django.views import View
+from django.views.generic.base import View
 from nacl.exceptions import CryptoError
 
 from . import signals


### PR DESCRIPTION
Django under 1.10 don't have
```
__all__ = ['View']
```
https://github.com/django/django/blob/stable/1.10.x/django/views/__init__.py

So we get error 
```
  File "/home/egor/envs/********/lib/python2.7/site-packages/django_shared_session-0.3.1-py2.7.egg/shared_session/views.py", line 11, in <module>
    template_name = 'index.html'
ImportError: cannot import name View
```