### PR TITLE
fixed error in get_message under django 2.2+

### DIFF
--- a/shared_session/templatetags/shared_session.py
+++ b/shared_session/templatetags/shared_session.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.contrib.sessions.backends.base import UpdateError
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.encoding import force_text
 from django.utils.http import urlsafe_base64_encode
 
 register = template.Library()
@@ -55,7 +56,7 @@ class LoaderNode(template.Node):
             'dst': domain,
             'ts': timezone.now().isoformat()
         })
-        return urlsafe_base64_encode(enc_payload).decode('ascii')
+        return force_text(urlsafe_base64_encode(enc_payload), encoding='ascii')
 
     def build_url(self, domain, message):
         return urljoin(domain, reverse('shared_session:share', kwargs={'message': message}))


### PR DESCRIPTION
`urlsafe_base64_encode` changed in django 2.2 so we get an exception:
`.../env/lib/python3.5/site-packages/shared_session/templatetags/shared_session.py", line 58, in get_message          return urlsafe_base64_encode(enc_payload).decode('ascii')
AttributeError: 'str' object has no attribute 'decode'
`

See [Django Docs](https://docs.djangoproject.com/en/2.2/ref/utils/):
> urlsafe_base64_encode(s):
> Encodes a bytestring to a base64 string for use in URLs, stripping any trailing equal signs.
> **Changed in Django 2.2:**
> **In older versions, it returns a bytestring instead of a string.**

I'm using Django's `force_text` to fix this issue and keep it backward compatible. Seems to work, tested it in 2.1.8 and 2.2.