### PR TITLE
set SameSite=none for cookies

### DIFF
--- a/shared_session/views.py
+++ b/shared_session/views.py
@@ -52,6 +52,7 @@ class SharedSessionView(View):
                         path=settings.SESSION_COOKIE_PATH,
                         secure=settings.SESSION_COOKIE_SECURE or None,
                         httponly=settings.SESSION_COOKIE_HTTPONLY or None,
+                        samesite='none',
                     )
 
                     # ensure CSRF cookie is set


### PR DESCRIPTION
Starting from Chrome 80, cookies without SameSite are treated at SameSite=lax, meaning they will only work if set from a subdomain of the same site. For the shared_session to actually work with unrelated domains, the handler must explicitly set `SameSite=none` in the response (it will also require a secure cookie, but that's a different story).